### PR TITLE
[GH-37] fixed bug tied to unhandled player input in battle scene 

### DIFF
--- a/.vscode/vscode-kanban.json
+++ b/.vscode/vscode-kanban.json
@@ -141,5 +141,24 @@
   ],
   "in-progress": [],
   "testing": [],
-  "done": []
+  "done": [
+    {
+      "assignedTo": {
+        "name": "Scott Westover"
+      },
+      "creation_time": "2023-12-01T18:39:13.333Z",
+      "description": {
+        "content": "when battle scene starts, block input during animations",
+        "mime": "text/markdown"
+      },
+      "details": {
+        "content": "When the battle scene starts, while we are playing animations, players can press input which will mess up the text animations that are being shown in the game. We need to block input, except when expecting input to move the text.\n\nTied to https://github.com/devshareacademy/monster-tamer/issues/37",
+        "mime": "text/markdown"
+      },
+      "id": "9",
+      "references": [],
+      "title": "Battle Scene - block input at scene start",
+      "type": "bug"
+    }
+  ]
 }

--- a/src/scenes/battle-scene.js
+++ b/src/scenes/battle-scene.js
@@ -90,6 +90,7 @@ export class BattleScene extends Phaser.Scene {
     this.#attackManager = new AttackManager(this, this.#skipAnimations);
 
     this.#controls = new Controls(this);
+    this.#controls.lockInput = true;
   }
 
   /**
@@ -97,6 +98,10 @@ export class BattleScene extends Phaser.Scene {
    */
   update() {
     this.#battleStateMachine.update();
+
+    if (this.#controls.isInputLocked) {
+      return;
+    }
 
     const wasSpaceKeyPressed = this.#controls.wasSpaceKeyPressed();
     // limit input based on the current battle state we are in
@@ -286,6 +291,7 @@ export class BattleScene extends Phaser.Scene {
         // wait for enemy monster to appear on the screen and notify player about the wild monster
         this.#activeEnemyMonster.playMonsterAppearAnimation(() => {
           this.#activeEnemyMonster.playMonsterHealthBarAppearAnimation(() => undefined);
+          this.#controls.lockInput = false;
           this.#battleMenu.updateInfoPaneMessagesAndWaitForInput(
             [`wild ${this.#activeEnemyMonster.name} appeared!`],
             () => {

--- a/src/scenes/preload-scene.js
+++ b/src/scenes/preload-scene.js
@@ -193,7 +193,7 @@ export class PreloadScene extends Phaser.Scene {
     dataManager.loadData();
 
     this.#createAnimations();
-    this.scene.start(SCENE_KEYS.BATTLE_SCENE);
+    this.scene.start(SCENE_KEYS.TITLE_SCENE);
   }
 
   /**

--- a/src/scenes/preload-scene.js
+++ b/src/scenes/preload-scene.js
@@ -193,7 +193,7 @@ export class PreloadScene extends Phaser.Scene {
     dataManager.loadData();
 
     this.#createAnimations();
-    this.scene.start(SCENE_KEYS.TITLE_SCENE);
+    this.scene.start(SCENE_KEYS.BATTLE_SCENE);
   }
 
   /**


### PR DESCRIPTION
Added additional safety guards to handle player input issues in the
battle scene at the start of the battle were the player could start
pressing the okay key in the pre-battle-info state, which would cause
multiple lines of text to be rendered, since we don't wait for the animation
to complete.

To address the issue, I locked the controls at the start of the scene and
only unlock them once the state machine gets to the pre battle info state
and the animations are done.

GitHub Issue: https://github.com/devshareacademy/monster-tamer/issues/37

Signed-off-by: Scott Westover <scottwestover2006@gmail.com>