### PR TITLE
[GH-63] fixed bug with saving player direction

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "chrome",
+      "request": "launch",
+      "name": "Launch Chrome against localhost",
+      "url": "http://localhost:5500",
+      "webRoot": "${workspaceFolder}"
+    }
+  ]
+}

--- a/src/scenes/world-scene.js
+++ b/src/scenes/world-scene.js
@@ -143,6 +143,9 @@ export class WorldScene extends Phaser.Scene {
       spriteGridMovementFinishedCallback: () => {
         this.#handlePlayerMovementUpdate();
       },
+      spriteChangedDirectionCallback: () => {
+        this.#handlePlayerDirectionUpdate();
+      },
     });
     this.cameras.main.startFollow(this.#player.sprite);
 
@@ -379,8 +382,6 @@ export class WorldScene extends Phaser.Scene {
       x: this.#player.sprite.x,
       y: this.#player.sprite.y,
     });
-    // update player direction on global data store
-    dataManager.store.set(DATA_MANAGER_STORE_KEYS.PLAYER_DIRECTION, this.#player.direction);
 
     if (DISABLE_WILD_ENCOUNTERS) {
       return;
@@ -405,6 +406,14 @@ export class WorldScene extends Phaser.Scene {
         this.scene.start(SCENE_KEYS.BATTLE_SCENE);
       });
     }
+  }
+
+  /**
+   * @returns {void}
+   */
+  #handlePlayerDirectionUpdate() {
+    // update player direction on global data store
+    dataManager.store.set(DATA_MANAGER_STORE_KEYS.PLAYER_DIRECTION, this.#player.direction);
   }
 
   /**

--- a/src/world/characters/character.js
+++ b/src/world/characters/character.js
@@ -22,6 +22,7 @@ import { exhaustiveGuard } from '../../utils/guard.js';
  * @property {Character[]} [otherCharactersToCheckForCollisionWith=[]]
  * @property {import('../../common/direction.js').Direction} direction
  * @property {() => void} [spriteGridMovementFinishedCallback]
+ * @property {() => void} [spriteChangedDirectionCallback]
  */
 
 /**
@@ -60,6 +61,8 @@ export class Character {
   _otherCharactersToCheckForCollisionWith;
   /** @protected @type {Phaser.Tilemaps.TilemapLayer | undefined} */
   _collisionLayer;
+  /** @protected @type {() => void | undefined} */
+  _spriteChangedDirectionCallback;
 
   /**
    * @param {CharacterConfig} config
@@ -82,6 +85,7 @@ export class Character {
       .sprite(config.position.x, config.position.y, config.assetKey, this._getIdleFrame())
       .setOrigin(this._origin.x, this._origin.y);
     this._spriteGridMovementFinishedCallback = config.spriteGridMovementFinishedCallback;
+    this._spriteChangedDirectionCallback = config.spriteChangedDirectionCallback;
   }
 
   /** @type {Phaser.GameObjects.Sprite} */
@@ -162,10 +166,19 @@ export class Character {
    * @returns {void}
    */
   _moveSprite(direction) {
+    const changedDirection = this._direction !== direction;
     this._direction = direction;
+
+    if (changedDirection) {
+      if (this._spriteChangedDirectionCallback !== undefined) {
+        this._spriteChangedDirectionCallback();
+      }
+    }
+
     if (this._isBlockingTile()) {
       return;
     }
+
     this._isMoving = true;
     this.#handleSpriteMovement();
   }


### PR DESCRIPTION
Addressed bug were the players direction would not be saved properly if the player never actually moved in the game. To address this issue, I added a new callback to be invoked when the characters sprite direction has changed. This callback is optional, and when invoked, the new direction will be stored in the data manager.

GitHub Issue: https://github.com/devshareacademy/monster-tamer/issues/63