### PR TITLE
[GH-81] persist monster data to data manager

### DIFF
--- a/src/battle/monsters/battle-monster.js
+++ b/src/battle/monsters/battle-monster.js
@@ -52,6 +52,11 @@ export class BattleMonster {
     });
   }
 
+  /** @type {number} */
+  get currentHp() {
+    return this._currentHealth;
+  }
+
   /** @type {boolean} */
   get isFainted() {
     return this._currentHealth <= 0;

--- a/src/config.js
+++ b/src/config.js
@@ -1,7 +1,7 @@
 export const TILED_COLLISION_LAYER_ALPHA = 0;
 export const TILE_SIZE = 64;
 export const WALK_FRAME_RATE = 6;
-export const DISABLE_WILD_ENCOUNTERS = true;
+export const DISABLE_WILD_ENCOUNTERS = false;
 export const TEXT_SPEED = Object.freeze({
   SLOW: 50,
   MEDIUM: 30,

--- a/src/scenes/battle-scene.js
+++ b/src/scenes/battle-scene.js
@@ -8,7 +8,6 @@ import { StateMachine } from '../utils/state-machine.js';
 import { Background } from '../battle/background.js';
 import { ATTACK_TARGET, AttackManager } from '../battle/attacks/attack-manager.js';
 import { createSceneTransition } from '../utils/scene-transition.js';
-// import { DataUtils } from '../utils/data-utils.js';
 import { DATA_MANAGER_STORE_KEYS, dataManager } from '../utils/data-manager.js';
 import { BATTLE_SCENE_OPTIONS } from '../common/options.js';
 import { BaseScene } from './base-scene.js';
@@ -78,6 +77,8 @@ export class BattleScene extends BaseScene {
     }
 
     this.#activePlayerAttackIndex = -1;
+    this.#activePlayerMonsterPartyIndex = 0;
+
     /** @type {import('../common/options.js').BattleSceneMenuOptions | undefined} */
     const chosenBattleSceneOption = dataManager.store.get(DATA_MANAGER_STORE_KEYS.OPTIONS_BATTLE_SCENE_ANIMATIONS);
     if (chosenBattleSceneOption === undefined || chosenBattleSceneOption === BATTLE_SCENE_OPTIONS.ON) {
@@ -85,7 +86,6 @@ export class BattleScene extends BaseScene {
       return;
     }
     this.#skipAnimations = true;
-    this.#activePlayerMonsterPartyIndex = 0;
   }
 
   /**
@@ -101,13 +101,11 @@ export class BattleScene extends BaseScene {
     // create the player and enemy monsters
     this.#activeEnemyMonster = new EnemyBattleMonster({
       scene: this,
-      // monsterDetails: DataUtils.getCarnodusk(this),
       monsterDetails: this.#sceneData.enemyMonsters[0],
       skipBattleAnimations: this.#skipAnimations,
     });
     this.#activePlayerMonster = new PlayerBattleMonster({
       scene: this,
-      // monsterDetails: DataUtils.getIguanignite(this),
       monsterDetails: this.#sceneData.playerMonsters[0],
       skipBattleAnimations: this.#skipAnimations,
     });
@@ -232,7 +230,7 @@ export class BattleScene extends BaseScene {
               this.#activePlayerMonster.playTakeDamageAnimation(() => {
                 this.#sceneData.playerMonsters[this.#activePlayerMonsterPartyIndex].currentHp =
                   this.#activePlayerMonster.currentHp;
-                dataManager.updateMonstersInPartyDetails(this.#sceneData.playerMonsters);
+                dataManager.store.set(DATA_MANAGER_STORE_KEYS.MONSTERS_IN_PARTY, this.#sceneData.playerMonsters);
                 this.#activePlayerMonster.takeDamage(this.#activeEnemyMonster.baseAttack, () => {
                   callback();
                 });

--- a/src/scenes/battle-scene.js
+++ b/src/scenes/battle-scene.js
@@ -228,10 +228,10 @@ export class BattleScene extends BaseScene {
             ATTACK_TARGET.PLAYER,
             () => {
               this.#activePlayerMonster.playTakeDamageAnimation(() => {
-                this.#sceneData.playerMonsters[this.#activePlayerMonsterPartyIndex].currentHp =
-                  this.#activePlayerMonster.currentHp;
-                dataManager.store.set(DATA_MANAGER_STORE_KEYS.MONSTERS_IN_PARTY, this.#sceneData.playerMonsters);
                 this.#activePlayerMonster.takeDamage(this.#activeEnemyMonster.baseAttack, () => {
+                  this.#sceneData.playerMonsters[this.#activePlayerMonsterPartyIndex].currentHp =
+                    this.#activePlayerMonster.currentHp;
+                  dataManager.store.set(DATA_MANAGER_STORE_KEYS.MONSTERS_IN_PARTY, this.#sceneData.playerMonsters);
                   callback();
                 });
               });

--- a/src/scenes/battle-scene.js
+++ b/src/scenes/battle-scene.js
@@ -52,6 +52,8 @@ export class BattleScene extends BaseScene {
   #activeEnemyAttackIndex;
   /** @type {BattleSceneData} */
   #sceneData;
+  /** @type {number} */
+  #activePlayerMonsterPartyIndex;
 
   constructor() {
     super({
@@ -83,6 +85,7 @@ export class BattleScene extends BaseScene {
       return;
     }
     this.#skipAnimations = true;
+    this.#activePlayerMonsterPartyIndex = 0;
   }
 
   /**
@@ -227,6 +230,9 @@ export class BattleScene extends BaseScene {
             ATTACK_TARGET.PLAYER,
             () => {
               this.#activePlayerMonster.playTakeDamageAnimation(() => {
+                this.#sceneData.playerMonsters[this.#activePlayerMonsterPartyIndex].currentHp =
+                  this.#activePlayerMonster.currentHp;
+                dataManager.updateMonstersInPartyDetails(this.#sceneData.playerMonsters);
                 this.#activePlayerMonster.takeDamage(this.#activeEnemyMonster.baseAttack, () => {
                   callback();
                 });

--- a/src/scenes/battle-scene.js
+++ b/src/scenes/battle-scene.js
@@ -8,10 +8,11 @@ import { StateMachine } from '../utils/state-machine.js';
 import { Background } from '../battle/background.js';
 import { ATTACK_TARGET, AttackManager } from '../battle/attacks/attack-manager.js';
 import { createSceneTransition } from '../utils/scene-transition.js';
-import { DataUtils } from '../utils/data-utils.js';
+// import { DataUtils } from '../utils/data-utils.js';
 import { DATA_MANAGER_STORE_KEYS, dataManager } from '../utils/data-manager.js';
 import { BATTLE_SCENE_OPTIONS } from '../common/options.js';
 import { BaseScene } from './base-scene.js';
+import { DataUtils } from '../utils/data-utils.js';
 
 const BATTLE_STATES = Object.freeze({
   INTRO: 'INTRO',
@@ -24,6 +25,13 @@ const BATTLE_STATES = Object.freeze({
   FINISHED: 'FINISHED',
   FLEE_ATTEMPT: 'FLEE_ATTEMPT',
 });
+
+/**
+ * @typedef BattleSceneData
+ * @type {object}
+ * @property {import('../types/typedef.js').Monster[]} playerMonsters
+ * @property {import('../types/typedef.js').Monster[]} enemyMonsters
+ */
 
 export class BattleScene extends BaseScene {
   /** @type {BattleMenu} */
@@ -42,6 +50,8 @@ export class BattleScene extends BaseScene {
   #skipAnimations;
   /** @type {number} */
   #activeEnemyAttackIndex;
+  /** @type {BattleSceneData} */
+  #sceneData;
 
   constructor() {
     super({
@@ -50,10 +60,20 @@ export class BattleScene extends BaseScene {
   }
 
   /**
+   * @param {BattleSceneData} data
    * @returns {void}
    */
-  init() {
-    super.init();
+  init(data) {
+    super.init(data);
+    this.#sceneData = data;
+
+    // added for testing from preload scene
+    if (Object.keys(data).length === 0) {
+      this.#sceneData = {
+        enemyMonsters: [DataUtils.getCarnodusk(this)],
+        playerMonsters: [DataUtils.getIguanignite(this)],
+      };
+    }
 
     this.#activePlayerAttackIndex = -1;
     /** @type {import('../common/options.js').BattleSceneMenuOptions | undefined} */
@@ -78,12 +98,14 @@ export class BattleScene extends BaseScene {
     // create the player and enemy monsters
     this.#activeEnemyMonster = new EnemyBattleMonster({
       scene: this,
-      monsterDetails: DataUtils.getCarnodusk(this),
+      // monsterDetails: DataUtils.getCarnodusk(this),
+      monsterDetails: this.#sceneData.enemyMonsters[0],
       skipBattleAnimations: this.#skipAnimations,
     });
     this.#activePlayerMonster = new PlayerBattleMonster({
       scene: this,
-      monsterDetails: DataUtils.getIguanignite(this),
+      // monsterDetails: DataUtils.getIguanignite(this),
+      monsterDetails: this.#sceneData.playerMonsters[0],
       skipBattleAnimations: this.#skipAnimations,
     });
 

--- a/src/scenes/monster-party-scene.js
+++ b/src/scenes/monster-party-scene.js
@@ -8,12 +8,11 @@ import {
 } from '../assets/asset-keys.js';
 import { KENNEY_FUTURE_NARROW_FONT_NAME } from '../assets/font-keys.js';
 import { HealthBar } from '../battle/ui/health-bar.js';
-import { DataUtils } from '../utils/data-utils.js';
 import { DIRECTION } from '../common/direction.js';
 import { exhaustiveGuard } from '../utils/guard.js';
 import { ITEM_EFFECT } from '../types/typedef.js';
 import { BaseScene } from './base-scene.js';
-import { dataManager } from '../utils/data-manager.js';
+import { DATA_MANAGER_STORE_KEYS, dataManager } from '../utils/data-manager.js';
 
 /** @type {Phaser.Types.GameObjects.Text.TextStyle} */
 const UI_TEXT_STYLE = {
@@ -71,7 +70,7 @@ export class MonsterPartyScene extends BaseScene {
     super.init(data);
 
     this.#selectedPartyMonsterIndex = 0;
-    this.#monsters = dataManager.getMonstersInParty(this);
+    this.#monsters = dataManager.store.get(DATA_MANAGER_STORE_KEYS.MONSTERS_IN_PARTY);
 
     this.#monsterPartyBackgrounds = [];
     this.#sceneData = data;

--- a/src/scenes/monster-party-scene.js
+++ b/src/scenes/monster-party-scene.js
@@ -57,6 +57,8 @@ export class MonsterPartyScene extends BaseScene {
   #waitingForInput;
   /** @type {HealthBar[]} */
   #healthBars;
+  /** @type {Phaser.GameObjects.Text[]} */
+  #healthBarTextGameObjects;
 
   constructor() {
     super({ key: SCENE_KEYS.MONSTER_PARTY_SCENE });
@@ -76,6 +78,7 @@ export class MonsterPartyScene extends BaseScene {
     this.#sceneData = data;
     this.#waitingForInput = false;
     this.#healthBars = [];
+    this.#healthBarTextGameObjects = [];
   }
 
   /**
@@ -244,6 +247,7 @@ export class MonsterPartyScene extends BaseScene {
         fontSize: '38px',
       })
       .setOrigin(1, 0);
+    this.#healthBarTextGameObjects.push(healthBarTextGameObject);
 
     const monsterImage = this.add.image(35, 20, monsterDetails.assetKey).setOrigin(0).setScale(0.35);
 
@@ -373,6 +377,11 @@ export class MonsterPartyScene extends BaseScene {
       this.#monsters[this.#selectedPartyMonsterIndex].currentHp / this.#monsters[this.#selectedPartyMonsterIndex].maxHp,
       {
         callback: () => {
+          this.#healthBarTextGameObjects[this.#selectedPartyMonsterIndex].setText(
+            `${this.#monsters[this.#selectedPartyMonsterIndex].currentHp} / ${
+              this.#monsters[this.#selectedPartyMonsterIndex].maxHp
+            }`
+          );
           this.time.delayedCall(300, () => {
             this.#goBackToPreviousScene(true);
           });

--- a/src/scenes/monster-party-scene.js
+++ b/src/scenes/monster-party-scene.js
@@ -346,7 +346,6 @@ export class MonsterPartyScene extends BaseScene {
    * @returns {void}
    */
   #handleHealItemUsed(amount) {
-    console.log(this.#sceneData.itemSelected);
     // validate that the monster is not fainted
     if (this.#monsters[this.#selectedPartyMonsterIndex].currentHp === 0) {
       this.#infoTextGameObject.setText('Cannot heal fainted monster');
@@ -382,6 +381,7 @@ export class MonsterPartyScene extends BaseScene {
               this.#monsters[this.#selectedPartyMonsterIndex].maxHp
             }`
           );
+          dataManager.store.set(DATA_MANAGER_STORE_KEYS.MONSTERS_IN_PARTY, this.#monsters);
           this.time.delayedCall(300, () => {
             this.#goBackToPreviousScene(true);
           });

--- a/src/scenes/monster-party-scene.js
+++ b/src/scenes/monster-party-scene.js
@@ -13,6 +13,7 @@ import { DIRECTION } from '../common/direction.js';
 import { exhaustiveGuard } from '../utils/guard.js';
 import { ITEM_EFFECT } from '../types/typedef.js';
 import { BaseScene } from './base-scene.js';
+import { dataManager } from '../utils/data-manager.js';
 
 /** @type {Phaser.Types.GameObjects.Text.TextStyle} */
 const UI_TEXT_STYLE = {
@@ -70,14 +71,7 @@ export class MonsterPartyScene extends BaseScene {
     super.init(data);
 
     this.#selectedPartyMonsterIndex = 0;
-    this.#monsters = [];
-
-    // added for testing from preload scene
-    // TODO: need to add logic to grab monster party data from the data manager
-    if (this.#monsters.length === 0) {
-      this.#monsters.push(DataUtils.getIguanignite(this));
-      // this.#monsters.push(DataUtils.getCarnodusk(this));
-    }
+    this.#monsters = dataManager.getMonstersInParty(this);
 
     this.#monsterPartyBackgrounds = [];
     this.#sceneData = data;

--- a/src/scenes/preload-scene.js
+++ b/src/scenes/preload-scene.js
@@ -16,8 +16,8 @@ import {
 import { SCENE_KEYS } from './scene-keys.js';
 import { WebFontFileLoader } from '../assets/web-font-file-loader.js';
 import { KENNEY_FUTURE_NARROW_FONT_NAME } from '../assets/font-keys.js';
-import { DIRECTION } from '../common/direction.js';
-import { WALK_FRAME_RATE } from '../config.js';
+// import { DIRECTION } from '../common/direction.js';
+// import { WALK_FRAME_RATE } from '../config.js';
 import { dataManager } from '../utils/data-manager.js';
 import { DataUtils } from '../utils/data-utils.js';
 import { BaseScene } from './base-scene.js';
@@ -175,7 +175,7 @@ export class PreloadScene extends BaseScene {
     // create animations from json file
     this.#createAnimations();
 
-    this.scene.start(SCENE_KEYS.TITLE_SCENE);
+    this.scene.start(SCENE_KEYS.BATTLE_SCENE);
   }
 
   /**

--- a/src/scenes/preload-scene.js
+++ b/src/scenes/preload-scene.js
@@ -175,7 +175,7 @@ export class PreloadScene extends BaseScene {
     // create animations from json file
     this.#createAnimations();
 
-    this.scene.start(SCENE_KEYS.WORLD_SCENE);
+    this.scene.start(SCENE_KEYS.TITLE_SCENE);
   }
 
   /**

--- a/src/scenes/preload-scene.js
+++ b/src/scenes/preload-scene.js
@@ -175,7 +175,7 @@ export class PreloadScene extends BaseScene {
     // create animations from json file
     this.#createAnimations();
 
-    this.scene.start(SCENE_KEYS.BATTLE_SCENE);
+    this.scene.start(SCENE_KEYS.TITLE_SCENE);
   }
 
   /**

--- a/src/scenes/preload-scene.js
+++ b/src/scenes/preload-scene.js
@@ -175,7 +175,7 @@ export class PreloadScene extends BaseScene {
     // create animations from json file
     this.#createAnimations();
 
-    this.scene.start(SCENE_KEYS.TITLE_SCENE);
+    this.scene.start(SCENE_KEYS.WORLD_SCENE);
   }
 
   /**

--- a/src/scenes/world-scene.js
+++ b/src/scenes/world-scene.js
@@ -404,7 +404,7 @@ export class WorldScene extends BaseScene {
         /** @type {import('./battle-scene.js').BattleSceneData} */
         const dataToPass = {
           enemyMonsters: [DataUtils.getCarnodusk(this)],
-          playerMonsters: [DataUtils.getIguanignite(this)], // TODO: pull this from data manager
+          playerMonsters: dataManager.getMonstersInParty(this),
         };
 
         this.scene.start(SCENE_KEYS.BATTLE_SCENE, dataToPass);

--- a/src/scenes/world-scene.js
+++ b/src/scenes/world-scene.js
@@ -12,6 +12,7 @@ import { DialogUi } from '../world/dialog-ui.js';
 import { Menu } from '../world/menu/menu.js';
 import { createBuildingSceneTransition } from '../utils/scene-transition.js';
 import { BaseScene } from './base-scene.js';
+import { DataUtils } from '../utils/data-utils.js';
 
 /**
  * @typedef WorldSceneData
@@ -399,7 +400,14 @@ export class WorldScene extends BaseScene {
       // add in a custom animation that is similar to the old games
       this.cameras.main.fadeOut(2000);
       this.cameras.main.once(Phaser.Cameras.Scene2D.Events.FADE_OUT_COMPLETE, () => {
-        this.scene.start(SCENE_KEYS.BATTLE_SCENE);
+        // TODO: add logic to determine monster that was encountered
+        /** @type {import('./battle-scene.js').BattleSceneData} */
+        const dataToPass = {
+          enemyMonsters: [DataUtils.getCarnodusk(this)],
+          playerMonsters: [DataUtils.getIguanignite(this)], // TODO: pull this from data manager
+        };
+
+        this.scene.start(SCENE_KEYS.BATTLE_SCENE, dataToPass);
       });
     }
   }

--- a/src/scenes/world-scene.js
+++ b/src/scenes/world-scene.js
@@ -404,7 +404,7 @@ export class WorldScene extends BaseScene {
         /** @type {import('./battle-scene.js').BattleSceneData} */
         const dataToPass = {
           enemyMonsters: [DataUtils.getCarnodusk(this)],
-          playerMonsters: dataManager.getMonstersInParty(this),
+          playerMonsters: dataManager.store.get(DATA_MANAGER_STORE_KEYS.MONSTERS_IN_PARTY),
         };
 
         this.scene.start(SCENE_KEYS.BATTLE_SCENE, dataToPass);

--- a/src/types/typedef.js
+++ b/src/types/typedef.js
@@ -10,17 +10,26 @@ import Phaser from '../lib/phaser.js';
  */
 
 /**
- * @typedef Monster
+ * @typedef BaseMonster
  * @type {object}
  * @property {number} id the unique identifier for this monster
- * @property {string} name the name of the monster
- * @property {string} assetKey the name of the asset key that should be used for this monster
- * @property {number} [assetFrame=0] if the asset key is tied to a spritesheet, this frame will be used, defaults to 0
  * @property {number} currentLevel the current level of this monster
  * @property {number} maxHp the max health of this monster
  * @property {number} currentHp the max health of this monster
  * @property {number} baseAttack the base attack value of this monster
+ */
+
+/**
+ * @typedef MonsterProps
+ * @type {object}
+ * @property {string} name the name of the monster
+ * @property {string} assetKey the name of the asset key that should be used for this monster
+ * @property {number} [assetFrame=0] if the asset key is tied to a spritesheet, this frame will be used, defaults to 0
  * @property {number[]} attackIds the ids of the attacks this monster uses
+ */
+
+/**
+ * @typedef {BaseMonster & MonsterProps} Monster
  */
 
 /**

--- a/src/types/typedef.js
+++ b/src/types/typedef.js
@@ -13,6 +13,7 @@ import Phaser from '../lib/phaser.js';
  * @typedef BaseMonster
  * @type {object}
  * @property {number} id the unique identifier for this monster
+ * @property {number} monsterId the unique identifier for this monster type
  * @property {number} currentLevel the current level of this monster
  * @property {number} maxHp the max health of this monster
  * @property {number} currentHp the max health of this monster

--- a/src/utils/data-manager.js
+++ b/src/utils/data-manager.js
@@ -3,6 +3,7 @@ import { TEXT_SPEED, TILE_SIZE } from '../config.js';
 import { DIRECTION } from '../common/direction.js';
 import { BATTLE_SCENE_OPTIONS, BATTLE_STYLE_OPTIONS, SOUND_OPTIONS, TEXT_SPEED_OPTIONS } from '../common/options.js';
 import { exhaustiveGuard } from './guard.js';
+import { DataUtils } from './data-utils.js';
 
 const LOCAL_STORAGE_KEY = 'MONSTER_TAMER_DATA';
 
@@ -11,6 +12,12 @@ const LOCAL_STORAGE_KEY = 'MONSTER_TAMER_DATA';
  * @type {object}
  * @property {string} area
  * @property {boolean} isInterior
+ */
+
+/**
+ * @typedef MonsterData
+ * @type {object}
+ * @property {import('../types/typedef.js').BaseMonster[]} monsters.inParty
  */
 
 /**
@@ -31,8 +38,7 @@ const LOCAL_STORAGE_KEY = 'MONSTER_TAMER_DATA';
  * @property {import('../common/options.js').VolumeMenuOptions} options.menuColor
  * @property {boolean} gameStarted
  * @property {import('../types/typedef.js').Inventory} inventory
- * @property {object} monsters
- * @property {import('../types/typedef.js').BaseMonster[]} monsters.inParty
+ * @property {MonsterData} monsters
  */
 
 /** @type {GlobalState} */
@@ -64,7 +70,7 @@ const initialState = {
         id: 1,
         currentHp: 25,
         maxHp: 25,
-        baseAttack: 5,
+        baseAttack: 20,
         currentLevel: 5,
       },
     ],
@@ -83,7 +89,7 @@ export const DATA_MANAGER_STORE_KEYS = Object.freeze({
   OPTIONS_MENU_COLOR: 'OPTIONS_MENU_COLOR',
   GAME_STARTED: 'GAME_STARTED',
   INVENTORY: 'INVENTORY',
-  MONSTERS: 'MONSTERS',
+  MONSTERS_IN_PARTY: 'MONSTERS_IN_PARTY',
 });
 
 class DataManager extends Phaser.Events.EventEmitter {
@@ -189,6 +195,34 @@ class DataManager extends Phaser.Events.EventEmitter {
   }
 
   /**
+   * @param {Phaser.Scene} scene the Phaser 3 Scene to get cached JSON file from
+   * @returns {import('../types/typedef.js').Monster[]}
+   */
+  getMonstersInParty(scene) {
+    return DataUtils.createMonstersFromBaseMonsters(scene, this.#store.get(DATA_MANAGER_STORE_KEYS.MONSTERS_IN_PARTY));
+  }
+
+  /**
+   * @param {import('../types/typedef.js').Monster[]} monsters
+   */
+  updateMonstersInPartyDetails(monsters) {
+    this.#store.set(
+      DATA_MANAGER_STORE_KEYS.MONSTERS_IN_PARTY,
+      monsters.map((monster) => {
+        /** @type {import('../types/typedef.js').BaseMonster} */
+        const baseMonster = {
+          currentHp: monster.currentHp,
+          id: monster.id,
+          currentLevel: monster.currentLevel,
+          baseAttack: monster.baseAttack,
+          maxHp: monster.maxHp,
+        };
+        return baseMonster;
+      })
+    );
+  }
+
+  /**
    * @param {GlobalState} data
    * @returns {void}
    */
@@ -205,7 +239,7 @@ class DataManager extends Phaser.Events.EventEmitter {
       [DATA_MANAGER_STORE_KEYS.OPTIONS_MENU_COLOR]: data.options.menuColor,
       [DATA_MANAGER_STORE_KEYS.GAME_STARTED]: data.gameStarted,
       [DATA_MANAGER_STORE_KEYS.INVENTORY]: data.inventory,
-      [DATA_MANAGER_STORE_KEYS.MONSTERS]: data.monsters,
+      [DATA_MANAGER_STORE_KEYS.MONSTERS_IN_PARTY]: data.monsters.inParty,
     });
   }
 
@@ -230,7 +264,7 @@ class DataManager extends Phaser.Events.EventEmitter {
       gameStarted: this.#store.get(DATA_MANAGER_STORE_KEYS.GAME_STARTED),
       inventory: this.#store.get(DATA_MANAGER_STORE_KEYS.INVENTORY),
       monsters: {
-        inParty: [...this.#store.get(DATA_MANAGER_STORE_KEYS.MONSTERS)],
+        inParty: [...this.#store.get(DATA_MANAGER_STORE_KEYS.MONSTERS_IN_PARTY)],
       },
     };
   }

--- a/src/utils/data-manager.js
+++ b/src/utils/data-manager.js
@@ -31,6 +31,7 @@ const LOCAL_STORAGE_KEY = 'MONSTER_TAMER_DATA';
  * @property {import('../common/options.js').VolumeMenuOptions} options.menuColor
  * @property {boolean} gameStarted
  * @property {import('../types/typedef.js').Inventory} inventory
+ * @property {import('../types/typedef.js').BaseMonster[]} monsters
  */
 
 /** @type {GlobalState} */
@@ -56,6 +57,15 @@ const initialState = {
   },
   gameStarted: false,
   inventory: [],
+  monsters: [
+    {
+      id: 1,
+      currentHp: 25,
+      maxHp: 25,
+      baseAttack: 5,
+      currentLevel: 5,
+    },
+  ],
 };
 
 export const DATA_MANAGER_STORE_KEYS = Object.freeze({
@@ -70,6 +80,7 @@ export const DATA_MANAGER_STORE_KEYS = Object.freeze({
   OPTIONS_MENU_COLOR: 'OPTIONS_MENU_COLOR',
   GAME_STARTED: 'GAME_STARTED',
   INVENTORY: 'INVENTORY',
+  MONSTERS: 'MONSTERS',
 });
 
 class DataManager extends Phaser.Events.EventEmitter {
@@ -143,6 +154,7 @@ class DataManager extends Phaser.Events.EventEmitter {
     existingData.player.location = { ...initialState.player.location };
     existingData.gameStarted = initialState.gameStarted;
     existingData.inventory = initialState.inventory;
+    existingData.monsters = [...initialState.monsters];
 
     this.#store.reset();
     this.#updateDataManger(existingData);
@@ -188,6 +200,7 @@ class DataManager extends Phaser.Events.EventEmitter {
       [DATA_MANAGER_STORE_KEYS.OPTIONS_MENU_COLOR]: data.options.menuColor,
       [DATA_MANAGER_STORE_KEYS.GAME_STARTED]: data.gameStarted,
       [DATA_MANAGER_STORE_KEYS.INVENTORY]: data.inventory,
+      [DATA_MANAGER_STORE_KEYS.MONSTERS]: data.monsters,
     });
   }
 
@@ -211,6 +224,7 @@ class DataManager extends Phaser.Events.EventEmitter {
       },
       gameStarted: this.#store.get(DATA_MANAGER_STORE_KEYS.GAME_STARTED),
       inventory: this.#store.get(DATA_MANAGER_STORE_KEYS.INVENTORY),
+      monsters: [...this.#store.get(DATA_MANAGER_STORE_KEYS.MONSTERS)],
     };
   }
 }

--- a/src/utils/data-manager.js
+++ b/src/utils/data-manager.js
@@ -3,7 +3,6 @@ import { TEXT_SPEED, TILE_SIZE } from '../config.js';
 import { DIRECTION } from '../common/direction.js';
 import { BATTLE_SCENE_OPTIONS, BATTLE_STYLE_OPTIONS, SOUND_OPTIONS, TEXT_SPEED_OPTIONS } from '../common/options.js';
 import { exhaustiveGuard } from './guard.js';
-import { DataUtils } from './data-utils.js';
 
 const LOCAL_STORAGE_KEY = 'MONSTER_TAMER_DATA';
 
@@ -17,7 +16,7 @@ const LOCAL_STORAGE_KEY = 'MONSTER_TAMER_DATA';
 /**
  * @typedef MonsterData
  * @type {object}
- * @property {import('../types/typedef.js').BaseMonster[]} monsters.inParty
+ * @property {import('../types/typedef.js').Monster[]} monsters.inParty
  */
 
 /**
@@ -68,10 +67,15 @@ const initialState = {
     inParty: [
       {
         id: 1,
+        monsterId: 1,
         currentHp: 25,
         maxHp: 25,
         baseAttack: 20,
         currentLevel: 5,
+        assetKey: 'IGUANIGNITE',
+        name: 'iguanignite',
+        assetFrame: 0,
+        attackIds: [2],
       },
     ],
   },
@@ -192,34 +196,6 @@ class DataManager extends Phaser.Events.EventEmitter {
       default:
         exhaustiveGuard(chosenTextSpeed);
     }
-  }
-
-  /**
-   * @param {Phaser.Scene} scene the Phaser 3 Scene to get cached JSON file from
-   * @returns {import('../types/typedef.js').Monster[]}
-   */
-  getMonstersInParty(scene) {
-    return DataUtils.createMonstersFromBaseMonsters(scene, this.#store.get(DATA_MANAGER_STORE_KEYS.MONSTERS_IN_PARTY));
-  }
-
-  /**
-   * @param {import('../types/typedef.js').Monster[]} monsters
-   */
-  updateMonstersInPartyDetails(monsters) {
-    this.#store.set(
-      DATA_MANAGER_STORE_KEYS.MONSTERS_IN_PARTY,
-      monsters.map((monster) => {
-        /** @type {import('../types/typedef.js').BaseMonster} */
-        const baseMonster = {
-          currentHp: monster.currentHp,
-          id: monster.id,
-          currentLevel: monster.currentLevel,
-          baseAttack: monster.baseAttack,
-          maxHp: monster.maxHp,
-        };
-        return baseMonster;
-      })
-    );
   }
 
   /**

--- a/src/utils/data-manager.js
+++ b/src/utils/data-manager.js
@@ -31,7 +31,8 @@ const LOCAL_STORAGE_KEY = 'MONSTER_TAMER_DATA';
  * @property {import('../common/options.js').VolumeMenuOptions} options.menuColor
  * @property {boolean} gameStarted
  * @property {import('../types/typedef.js').Inventory} inventory
- * @property {import('../types/typedef.js').BaseMonster[]} monsters
+ * @property {object} monsters
+ * @property {import('../types/typedef.js').BaseMonster[]} monsters.inParty
  */
 
 /** @type {GlobalState} */
@@ -57,15 +58,17 @@ const initialState = {
   },
   gameStarted: false,
   inventory: [],
-  monsters: [
-    {
-      id: 1,
-      currentHp: 25,
-      maxHp: 25,
-      baseAttack: 5,
-      currentLevel: 5,
-    },
-  ],
+  monsters: {
+    inParty: [
+      {
+        id: 1,
+        currentHp: 25,
+        maxHp: 25,
+        baseAttack: 5,
+        currentLevel: 5,
+      },
+    ],
+  },
 };
 
 export const DATA_MANAGER_STORE_KEYS = Object.freeze({
@@ -154,7 +157,9 @@ class DataManager extends Phaser.Events.EventEmitter {
     existingData.player.location = { ...initialState.player.location };
     existingData.gameStarted = initialState.gameStarted;
     existingData.inventory = initialState.inventory;
-    existingData.monsters = [...initialState.monsters];
+    existingData.monsters = {
+      inParty: [...initialState.monsters.inParty],
+    };
 
     this.#store.reset();
     this.#updateDataManger(existingData);
@@ -224,7 +229,9 @@ class DataManager extends Phaser.Events.EventEmitter {
       },
       gameStarted: this.#store.get(DATA_MANAGER_STORE_KEYS.GAME_STARTED),
       inventory: this.#store.get(DATA_MANAGER_STORE_KEYS.INVENTORY),
-      monsters: [...this.#store.get(DATA_MANAGER_STORE_KEYS.MONSTERS)],
+      monsters: {
+        inParty: [...this.#store.get(DATA_MANAGER_STORE_KEYS.MONSTERS)],
+      },
     };
   }
 }

--- a/src/utils/data-utils.js
+++ b/src/utils/data-utils.js
@@ -44,4 +44,34 @@ export class DataUtils {
     const data = scene.cache.json.get(DATA_ASSET_KEYS.ANIMATIONS);
     return data;
   }
+
+  /**
+   * Utility function for retrieving the Animation objects from the animations.json data file.
+   * @param {Phaser.Scene} scene the Phaser 3 Scene to get cached JSON file from
+   * @param {import('../types/typedef.js').BaseMonster[]} baseMonsters the base monsters that need to be populated with data
+   * @returns {import('../types/typedef.js').Monster[]}
+   */
+  static createMonstersFromBaseMonsters(scene, baseMonsters) {
+    /** @type { import('../types/typedef.js').Monster[]} */
+    const data = scene.cache.json.get(DATA_ASSET_KEYS.MONSTERS);
+
+    /** @type {import('../types/typedef.js').Monster[]} */
+    const monsters = [];
+
+    baseMonsters.forEach((baseMonster) => {
+      const monsterData = data.find((monster) => monster.id === baseMonster.id);
+      if (!monsterData) {
+        return;
+      }
+      monsters.push({
+        ...baseMonster,
+        name: monsterData.name,
+        assetKey: monsterData.assetKey,
+        assetFrame: monsterData.assetFrame,
+        attackIds: [...monsterData.attackIds],
+      });
+    });
+
+    return monsters;
+  }
 }


### PR DESCRIPTION
- updated data manager to persist monster data for the monsters in the players party
- refactored logic for various scenes that start with hard coded monster data, to use the monster party data from the data manager
- created initial monster data in the the data manager