### PR TITLE
[GH-87] fixed bug with initial helth bar during battle

### DIFF
--- a/src/battle/monsters/battle-monster.js
+++ b/src/battle/monsters/battle-monster.js
@@ -43,6 +43,9 @@ export class BattleMonster {
       .image(position.x, position.y, this._monsterDetails.assetKey, this._monsterDetails.assetFrame || 0)
       .setAlpha(0);
     this.#createHealthBarComponents(config.scaleHealthBarBackgroundImageByY);
+    this._healthBar.setMeterPercentageAnimated(this._currentHealth / this._maxHealth, {
+      skipBattleAnimations: true,
+    });
 
     this._monsterDetails.attackIds.forEach((attackId) => {
       const monsterAttack = DataUtils.getMonsterAttack(this._scene, attackId);


### PR DESCRIPTION
fixed bug with the battle scene
were when a monster starts at partially health, the health bar would still be filled all of the way. to fx the issue, added logic to the battle monster class to make sure the health is set after the components are set