### PR TITLE
[GH-98] added logic for healing player when knocked out

### DIFF
--- a/assets/data/building_1.json
+++ b/assets/data/building_1.json
@@ -68,10 +68,11 @@
                  "x":0,
                  "y":0
                 }],
+         "locked":true,
          "name":"Main-Scene",
          "opacity":1,
          "type":"group",
-         "visible":false,
+         "visible":true,
          "x":0,
          "y":0
         }, 
@@ -91,7 +92,7 @@
          "name":"Collision",
          "opacity":0.68,
          "type":"tilelayer",
-         "visible":false,
+         "visible":true,
          "width":13,
          "x":0,
          "y":0
@@ -133,14 +134,39 @@
          "name":"Encounter",
          "opacity":1,
          "type":"tilelayer",
-         "visible":false,
+         "visible":true,
          "width":13,
          "x":0,
          "y":0
         }, 
         {
          "draworder":"topdown",
+         "id":14,
+         "locked":true,
+         "name":"Revive-Location",
+         "objects":[
+                {
+                 "gid":125,
+                 "height":64,
+                 "id":7,
+                 "name":"",
+                 "rotation":0,
+                 "type":"",
+                 "visible":true,
+                 "width":64,
+                 "x":576,
+                 "y":320
+                }],
+         "opacity":1,
+         "type":"objectgroup",
+         "visible":true,
+         "x":0,
+         "y":0
+        }, 
+        {
+         "draworder":"topdown",
          "id":6,
+         "locked":true,
          "name":"Scene-Transitions",
          "objects":[
                 {
@@ -173,12 +199,86 @@
                 }],
          "opacity":1,
          "type":"objectgroup",
-         "visible":false,
+         "visible":true,
+         "x":0,
+         "y":0
+        }, 
+        {
+         "draworder":"topdown",
+         "id":13,
+         "locked":true,
+         "name":"Area-Metadata",
+         "objects":[
+                {
+                 "gid":125,
+                 "height":64,
+                 "id":6,
+                 "name":"",
+                 "properties":[
+                        {
+                         "name":"faint_location",
+                         "type":"string",
+                         "value":"building_1"
+                        }, 
+                        {
+                         "name":"id",
+                         "type":"int",
+                         "value":0
+                        }],
+                 "rotation":0,
+                 "type":"area_metadata",
+                 "visible":true,
+                 "width":64,
+                 "x":128,
+                 "y":448
+                }],
+         "opacity":1,
+         "type":"objectgroup",
+         "visible":true,
+         "x":0,
+         "y":0
+        }, 
+        {
+         "id":11,
+         "layers":[
+                {
+                 "draworder":"topdown",
+                 "id":12,
+                 "name":"NPC1",
+                 "objects":[
+                        {
+                         "gid":125,
+                         "height":64,
+                         "id":5,
+                         "name":"NPC1",
+                         "properties":[
+                                {
+                                 "name":"id",
+                                 "type":"int",
+                                 "value":1
+                                }],
+                         "rotation":0,
+                         "type":"npc",
+                         "visible":true,
+                         "width":64,
+                         "x":576,
+                         "y":256
+                        }],
+                 "opacity":1,
+                 "type":"objectgroup",
+                 "visible":true,
+                 "x":0,
+                 "y":0
+                }],
+         "name":"NPC",
+         "opacity":1,
+         "type":"group",
+         "visible":true,
          "x":0,
          "y":0
         }],
- "nextlayerid":11,
- "nextobjectid":5,
+ "nextlayerid":15,
+ "nextobjectid":8,
  "orientation":"orthogonal",
  "renderorder":"right-down",
  "tiledversion":"1.10.0",

--- a/assets/data/main_1.json
+++ b/assets/data/main_1.json
@@ -564,6 +564,7 @@
         {
          "draworder":"topdown",
          "id":23,
+         "locked":true,
          "name":"Scene-Transitions",
          "objects":[
                 {
@@ -621,6 +622,41 @@
                  "width":64,
                  "x":832,
                  "y":1344
+                }],
+         "opacity":1,
+         "type":"objectgroup",
+         "visible":true,
+         "x":0,
+         "y":0
+        }, 
+        {
+         "draworder":"topdown",
+         "id":24,
+         "locked":true,
+         "name":"Area-Metadata",
+         "objects":[
+                {
+                 "gid":194,
+                 "height":64,
+                 "id":21,
+                 "name":"",
+                 "properties":[
+                        {
+                         "name":"faint_location",
+                         "type":"string",
+                         "value":"building_1"
+                        }, 
+                        {
+                         "name":"id",
+                         "type":"int",
+                         "value":0
+                        }],
+                 "rotation":0,
+                 "type":"area_metadata",
+                 "visible":true,
+                 "width":64,
+                 "x":192,
+                 "y":1408
                 }],
          "opacity":1,
          "type":"objectgroup",
@@ -718,7 +754,6 @@
                 {
                  "draworder":"topdown",
                  "id":18,
-                 "locked":true,
                  "name":"NPC1",
                  "objects":[
                         {
@@ -740,14 +775,9 @@
                          "name":"npc",
                          "properties":[
                                 {
-                                 "name":"frame",
-                                 "type":"string",
-                                 "value":"20"
-                                }, 
-                                {
-                                 "name":"messages",
-                                 "type":"string",
-                                 "value":"Make sure you read the signposts for helpful tips!"
+                                 "name":"id",
+                                 "type":"int",
+                                 "value":2
                                 }, 
                                 {
                                  "name":"movement_pattern",
@@ -843,7 +873,6 @@
                 {
                  "draworder":"topdown",
                  "id":20,
-                 "locked":true,
                  "name":"NPC2",
                  "objects":[
                         {
@@ -853,14 +882,9 @@
                          "name":"npc",
                          "properties":[
                                 {
-                                 "name":"frame",
-                                 "type":"string",
-                                 "value":"0"
-                                }, 
-                                {
-                                 "name":"messages",
-                                 "type":"string",
-                                 "value":"You can save your game from the menu.::To open the menu, press the ENTER key."
+                                 "name":"id",
+                                 "type":"int",
+                                 "value":3
                                 }, 
                                 {
                                  "name":"movement_pattern",
@@ -881,7 +905,6 @@
                  "x":0,
                  "y":0
                 }],
-         "locked":true,
          "name":"NPC",
          "opacity":1,
          "type":"group",
@@ -889,8 +912,8 @@
          "x":0,
          "y":0
         }],
- "nextlayerid":24,
- "nextobjectid":21,
+ "nextlayerid":25,
+ "nextobjectid":22,
  "orientation":"orthogonal",
  "renderorder":"right-down",
  "tiledversion":"1.10.0",

--- a/assets/data/npcs.json
+++ b/assets/data/npcs.json
@@ -1,0 +1,59 @@
+{
+  "1": {
+    "frame": 30,
+    "events": [
+      {
+        "type": "MESSAGE",
+        "data": {
+          "messages": ["You should take a quick rest."]
+        }
+      },
+      {
+        "type": "HEAL",
+        "data": {}
+      },
+      {
+        "type": "SCENE_FADE_IN_AND_OUT",
+        "data": {
+          "fadeInDuration": 1000,
+          "fadeOutDuration": 1000,
+          "waitDuration": 1500
+        }
+      },
+      {
+        "type": "MESSAGE",
+        "data": {
+          "messages": ["Oh good! You and monsters are looking great!"]
+        }
+      }
+    ]
+  },
+  "2": {
+    "frame": 20,
+    "events": [
+      {
+        "type": "MESSAGE",
+        "data": {
+          "messages": ["Make sure you read the signposts for helpful tips!"]
+        }
+      }
+    ]
+  },
+  "3": {
+    "frame": 0,
+    "events": [
+      {
+        "type": "MESSAGE",
+        "data": {
+          "messages": ["You can save your game from the menu."]
+        }
+      },
+      {
+        "type": "MESSAGE",
+        "data": {
+          "messages": ["To open the menu, press the ENTER key."]
+        }
+      }
+    ]
+  }
+}

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,0 +1,12 @@
+# Tips
+
+Before I wrap up the video series, I need to come up with some helpful guides for how people can extend the game, and continue to refine. Some initial ideas include:
+
+- Adding new npcs
+  - multiple lines of dialog (need to include `::`)
+- Adding new areas/buildings
+  - connecting the two
+- Adding new monsters
+- Adding new items
+- Buildings and various ids
+- Re-spawning

--- a/src/assets/asset-keys.js
+++ b/src/assets/asset-keys.js
@@ -47,6 +47,7 @@ export const DATA_ASSET_KEYS = Object.freeze({
   MONSTERS: 'MONSTERS',
   ANIMATIONS: 'ANIMATIONS',
   ENCOUNTERS: 'ENCOUNTERS',
+  NPCS: 'NPCS',
 });
 
 export const ATTACK_ASSET_KEYS = Object.freeze({

--- a/src/scenes/battle-scene.js
+++ b/src/scenes/battle-scene.js
@@ -53,6 +53,8 @@ export class BattleScene extends BaseScene {
   #sceneData;
   /** @type {number} */
   #activePlayerMonsterPartyIndex;
+  /** @type {boolean} */
+  #playerKnockedOut;
 
   constructor() {
     super({
@@ -86,6 +88,7 @@ export class BattleScene extends BaseScene {
       return;
     }
     this.#skipAnimations = true;
+    this.#playerKnockedOut = false;
   }
 
   /**
@@ -277,6 +280,7 @@ export class BattleScene extends BaseScene {
         this.#battleMenu.updateInfoPaneMessagesAndWaitForInput(
           [`${this.#activePlayerMonster.name} fainted.`, 'You have no more monsters, escaping to safety...'],
           () => {
+            this.#playerKnockedOut = true;
             this.#battleStateMachine.setState(BATTLE_STATES.FINISHED);
           }
         );
@@ -291,9 +295,13 @@ export class BattleScene extends BaseScene {
    * @returns {void}
    */
   #transitionToNextScene() {
+    /** @type {import('./world-scene.js').WorldSceneData} */
+    const sceneDataToPass = {
+      isPlayedKnockedOut: this.#playerKnockedOut,
+    };
     this.cameras.main.fadeOut(600, 0, 0, 0);
     this.cameras.main.once(Phaser.Cameras.Scene2D.Events.FADE_OUT_COMPLETE, () => {
-      this.scene.start(SCENE_KEYS.WORLD_SCENE);
+      this.scene.start(SCENE_KEYS.WORLD_SCENE, sceneDataToPass);
     });
   }
 

--- a/src/scenes/preload-scene.js
+++ b/src/scenes/preload-scene.js
@@ -114,6 +114,7 @@ export class PreloadScene extends BaseScene {
     this.load.json(DATA_ASSET_KEYS.MONSTERS, 'assets/data/monsters.json');
     this.load.json(DATA_ASSET_KEYS.ANIMATIONS, 'assets/data/animations.json');
     this.load.json(DATA_ASSET_KEYS.ENCOUNTERS, 'assets/data/encounters.json');
+    this.load.json(DATA_ASSET_KEYS.NPCS, 'assets/data/npcs.json');
 
     // load custom fonts
     this.load.addFile(new WebFontFileLoader(this.load, [KENNEY_FUTURE_NARROW_FONT_NAME]));

--- a/src/scenes/world-scene.js
+++ b/src/scenes/world-scene.js
@@ -14,6 +14,8 @@ import { createBuildingSceneTransition } from '../utils/scene-transition.js';
 import { BaseScene } from './base-scene.js';
 import { DataUtils } from '../utils/data-utils.js';
 import { weightedRandom } from '../utils/random.js';
+import { NPC_EVENT_TYPE } from '../types/typedef.js';
+import { exhaustiveGuard } from '../utils/guard.js';
 
 /**
  * @typedef WorldSceneData
@@ -36,10 +38,8 @@ const CUSTOM_TILED_TYPES = Object.freeze({
 });
 
 const TILED_NPC_PROPERTY = Object.freeze({
-  IS_SPAWN_POINT: 'is_spawn_point',
   MOVEMENT_PATTERN: 'movement_pattern',
-  MESSAGES: 'messages',
-  FRAME: 'frame',
+  ID: 'id',
 });
 
 const TILED_SIGN_PROPERTY = Object.freeze({
@@ -76,6 +76,8 @@ export class WorldScene extends BaseScene {
   #sceneData;
   /** @type {Phaser.Tilemaps.ObjectLayer} */
   #entranceLayer;
+  /** @type {number} */
+  #lastNpcEventHandledIndex;
 
   constructor() {
     super({
@@ -110,6 +112,7 @@ export class WorldScene extends BaseScene {
       })
     );
     this.#npcPlayerIsInteractingWith = undefined;
+    this.#lastNpcEventHandledIndex = -1;
   }
 
   /**
@@ -327,8 +330,7 @@ export class WorldScene extends BaseScene {
     if (this.#dialogUi.isVisible && !this.#dialogUi.moreMessagesToShow) {
       this.#dialogUi.hideDialogModal();
       if (this.#npcPlayerIsInteractingWith) {
-        this.#npcPlayerIsInteractingWith.isTalkingToPlayer = false;
-        this.#npcPlayerIsInteractingWith = undefined;
+        this.#handleNpcInteraction();
       }
       return;
     }
@@ -372,7 +374,7 @@ export class WorldScene extends BaseScene {
       nearbyNpc.facePlayer(this.#player.direction);
       nearbyNpc.isTalkingToPlayer = true;
       this.#npcPlayerIsInteractingWith = nearbyNpc;
-      this.#dialogUi.showDialogModal(nearbyNpc.messages);
+      this.#handleNpcInteraction();
       return;
     }
   }
@@ -465,32 +467,27 @@ export class WorldScene extends BaseScene {
         npcPath[parseInt(obj.name, 10)] = { x: obj.x, y: obj.y - TILE_SIZE };
       });
 
-      /** @type {string} */
-      const npcFrame =
-        /** @type {TiledObjectProperty[]} */ (npcObject.properties).find(
-          (property) => property.name === TILED_NPC_PROPERTY.FRAME
-        )?.value || '0';
-      /** @type {string} */
-      const npcMessagesString =
-        /** @type {TiledObjectProperty[]} */ (npcObject.properties).find(
-          (property) => property.name === TILED_NPC_PROPERTY.MESSAGES
-        )?.value || '';
-      const npcMessages = npcMessagesString.split('::');
       /** @type {import('../world/characters/npc.js').NpcMovementPattern} */
       const npcMovement =
         /** @type {TiledObjectProperty[]} */ (npcObject.properties).find(
           (property) => property.name === TILED_NPC_PROPERTY.MOVEMENT_PATTERN
         )?.value || 'IDLE';
 
+      /** @type {number} */
+      const npcId = /** @type {TiledObjectProperty[]} */ (npcObject.properties).find(
+        (property) => property.name === TILED_NPC_PROPERTY.ID
+      )?.value;
+      const npcDetails = DataUtils.getNpcData(this, npcId);
+
       // In Tiled, the x value is how far the object starts from the left, and the y is the bottom of tiled object that is being added
       const npc = new NPC({
         scene: this,
         position: { x: npcObject.x, y: npcObject.y - TILE_SIZE },
         direction: DIRECTION.DOWN,
-        frame: parseInt(npcFrame, 10),
-        messages: npcMessages,
+        frame: npcDetails.frame,
         npcPath,
         movementPattern: npcMovement,
+        events: npcDetails.events,
       });
       this.#npcs.push(npc);
     });
@@ -550,5 +547,62 @@ export class WorldScene extends BaseScene {
         this.scene.start(SCENE_KEYS.WORLD_SCENE, dataToPass);
       },
     });
+  }
+
+  /**
+   * @returns {void}
+   */
+  #handleNpcInteraction() {
+    // check to see if the npc has any events associated with them
+    const isMoreEventsToProcess = this.#npcPlayerIsInteractingWith.events.length - 1 !== this.#lastNpcEventHandledIndex;
+
+    if (!isMoreEventsToProcess) {
+      this.#npcPlayerIsInteractingWith.isTalkingToPlayer = false;
+      this.#npcPlayerIsInteractingWith = undefined;
+      this.#lastNpcEventHandledIndex = -1;
+      return;
+    }
+
+    // get the next event from the queue and process for this npc
+    this.#lastNpcEventHandledIndex += 1;
+    const eventToHandle = this.#npcPlayerIsInteractingWith.events[this.#lastNpcEventHandledIndex];
+    const eventType = eventToHandle.type;
+
+    switch (eventType) {
+      case NPC_EVENT_TYPE.MESSAGE:
+        this.#dialogUi.showDialogModal(eventToHandle.data.messages);
+        break;
+      case NPC_EVENT_TYPE.HEAL:
+        // heal all monsters in party
+        /** @type {import('../types/typedef.js').Monster[]} */
+        const monsters = dataManager.store.get(DATA_MANAGER_STORE_KEYS.MONSTERS_IN_PARTY);
+        monsters.forEach((monster) => {
+          monster.currentHp = monster.maxHp;
+        });
+        dataManager.store.set(DATA_MANAGER_STORE_KEYS.MONSTERS_IN_PARTY, monsters);
+        this.#handleNpcInteraction();
+        break;
+      case NPC_EVENT_TYPE.SCENE_FADE_IN_AND_OUT:
+        // lock input, and wait for scene to fade in and out
+        this._controls.lockInput = true;
+        this.cameras.main.fadeOut(eventToHandle.data.fadeOutDuration, 0, 0, 0, (fadeOutCamera, fadeOutProgress) => {
+          if (fadeOutProgress !== 1) {
+            return;
+          }
+          this.time.delayedCall(eventToHandle.data.waitDuration, () => {
+            this.cameras.main.fadeIn(eventToHandle.data.fadeInDuration, 0, 0, 0, (fadeInCamera, fadeInProgress) => {
+              if (fadeInProgress !== 1) {
+                return;
+              }
+              this._controls.lockInput = false;
+              this.#handleNpcInteraction();
+            });
+          });
+        });
+        // TODO: play audio cue
+        break;
+      default:
+        exhaustiveGuard(eventType);
+    }
   }
 }

--- a/src/scenes/world-scene.js
+++ b/src/scenes/world-scene.js
@@ -62,6 +62,8 @@ const TILED_AREA_META_DATA_PROPERTY = Object.freeze({
 */
 
 export class WorldScene extends BaseScene {
+  /** @type {Phaser.GameObjects.Rectangle} */
+  #backgroundRect;
   /** @type {Player} */
   #player;
   /** @type {Phaser.Tilemaps.TilemapLayer} */
@@ -222,7 +224,7 @@ export class WorldScene extends BaseScene {
     }
     this.cameras.main.setZoom(0.8);
 
-    const bgRect = this.add.rectangle(0, 0, 0, 0, 0x000000).setOrigin(0);
+    this.#backgroundRect = this.add.rectangle(0, 0, 0, 0, 0x000000).setOrigin(0);
     this.add.image(0, 0, `${this.#sceneData.area.toUpperCase()}_BACKGROUND`, 0).setOrigin(0);
 
     // create npcs
@@ -262,13 +264,10 @@ export class WorldScene extends BaseScene {
     // create menu
     this.#menu = new Menu(this);
 
-    let isBgRectUpdated = false;
-    // TODO: revisit and see if we need to use progress here
-    this.cameras.main.fadeIn(1000, 0, 0, 0, () => {
-      if (!isBgRectUpdated && this.cameras.main.worldView.width !== 0) {
-        bgRect.setSize(this.cameras.main.worldView.width, this.cameras.main.worldView.height);
-        bgRect.setPosition(this.cameras.main.worldView.x, this.cameras.main.worldView.y);
-        isBgRectUpdated = true;
+    this.cameras.main.fadeIn(1000, 0, 0, 0, (camera, progress) => {
+      if (progress === 1) {
+        this.#backgroundRect.setSize(this.cameras.main.worldView.width, this.cameras.main.worldView.height);
+        this.#backgroundRect.setPosition(this.cameras.main.worldView.x, this.cameras.main.worldView.y);
 
         // if the player was knocked out, we want to lock input, heal player, and then have npc show message
         if (this.#sceneData.isPlayedKnockedOut) {
@@ -583,6 +582,7 @@ export class WorldScene extends BaseScene {
       y += TILE_SIZE;
     }
 
+    this.#backgroundRect.setPosition(this.cameras.main.worldView.x, this.cameras.main.worldView.y);
     createBuildingSceneTransition(this, {
       callback: () => {
         dataManager.store.set(DATA_MANAGER_STORE_KEYS.PLAYER_POSITION, {

--- a/src/types/typedef.js
+++ b/src/types/typedef.js
@@ -94,3 +94,61 @@ export const ITEM_EFFECT = Object.freeze({
  * @typedef EncounterData
  * @type {Object.<string, number[][]>}
  */
+
+/** NPC JSON Data Types */
+
+/**
+ * @typedef {keyof typeof NPC_EVENT_TYPE} NpcEventType
+ */
+
+/** @enum {NpcEventType} */
+export const NPC_EVENT_TYPE = Object.freeze({
+  MESSAGE: 'MESSAGE',
+  SCENE_FADE_IN_AND_OUT: 'SCENE_FADE_IN_AND_OUT',
+  HEAL: 'HEAL',
+  TRADE: 'TRADE',
+  ITEM: 'ITEM',
+  BATTLE: 'BATTLE',
+});
+
+/**
+ * @typedef NpcEventMessage
+ * @type {object}
+ * @property {'MESSAGE'} type
+ * @property {object} data
+ * @property {string[]} data.messages
+ */
+
+/**
+ * @typedef NpcEventSceneFadeInAndOut
+ * @type {object}
+ * @property {'SCENE_FADE_IN_AND_OUT'} type
+ * @property {object} data
+ * @property {number} data.fadeInDuration
+ * @property {number} data.fadeOutDuration
+ * @property {number} data.waitDuration
+ */
+
+/**
+ * @typedef NpcEventHeal
+ * @type {object}
+ * @property {'HEAL'} type
+ * @property {object} data
+ */
+
+/**
+ * @typedef NpcEvent
+ * @type {NpcEventMessage | NpcEventSceneFadeInAndOut | NpcEventHeal}
+ */
+
+/**
+ * @typedef NpcDetails
+ * @type {object}
+ * @property {number} frame
+ * @property {NpcEvent[]} events
+ */
+
+/**
+ * @typedef NpcData
+ * @type {Object.<string, NpcDetails>}
+ */

--- a/src/utils/data-utils.js
+++ b/src/utils/data-utils.js
@@ -92,8 +92,19 @@ export class DataUtils {
    * @returns {import('../types/typedef.js').Monster}
    */
   static getMonsterById(scene, monsterId) {
-    /** @type { import('../types/typedef.js').Monster[]} */
+    /** @type {import('../types/typedef.js').Monster[]} */
     const data = scene.cache.json.get(DATA_ASSET_KEYS.MONSTERS);
     return data.find((monster) => monster.id === monsterId);
+  }
+
+  /**
+   * @param {Phaser.Scene} scene the Phaser 3 Scene to get cached JSON file from
+   * @param {number} npcId
+   * @returns {import('../types/typedef.js').NpcDetails}
+   */
+  static getNpcData(scene, npcId) {
+    /** @type {import('../types/typedef.js').NpcDetails} */
+    const data = scene.cache.json.get(DATA_ASSET_KEYS.NPCS);
+    return data[npcId];
   }
 }

--- a/src/world/characters/npc.js
+++ b/src/world/characters/npc.js
@@ -23,9 +23,10 @@ export const NPC_MOVEMENT_PATTERN = Object.freeze({
  * @typedef NPCConfigProps
  * @type {object}
  * @property {number} frame
- * @property {string[]} messages
+ * @property {string[]} [messages]
  * @property {NPCPath} npcPath
  * @property {NpcMovementPattern} movementPattern
+ * @property {import('../../types/typedef.js').NpcEvent[]} events
  */
 
 /**
@@ -33,8 +34,6 @@ export const NPC_MOVEMENT_PATTERN = Object.freeze({
  */
 
 export class NPC extends Character {
-  /** @type {string[]} */
-  #messages;
   /** @type {boolean} */
   #talkingToPlayer;
   /** @type {NPCPath} */
@@ -45,6 +44,8 @@ export class NPC extends Character {
   #movementPattern;
   /** @type {number} */
   #lastMovementTime;
+  /** @type {import('../../types/typedef.js').NpcEvent[]} */
+  #events;
 
   /**
    * @param {NPCConfig} config
@@ -63,18 +64,18 @@ export class NPC extends Character {
       },
     });
 
-    this.#messages = config.messages;
     this.#talkingToPlayer = false;
     this.#npcPath = config.npcPath;
     this.#currentPathIndex = 0;
     this.#movementPattern = config.movementPattern;
     this.#lastMovementTime = Phaser.Math.Between(3500, 5000);
     this._phaserGameObject.setScale(4);
+    this.#events = config.events;
   }
 
-  /** @type {string[]} */
-  get messages() {
-    return [...this.#messages];
+  /** @type {import('../../types/typedef.js').NpcEvent[]} */
+  get events() {
+    return [...this.#events];
   }
 
   /** @type {boolean} */


### PR DESCRIPTION
Refactored the creation of npcs to no longer look for the frame and
messages fields on the data in the Tiled JSON data file. Instead, there
is a new `npcs.json` file that will be used for this data and more.

The new json file includes an array of npc data, where the key is a unique
id for the npc. The data in the Tiled JSON data has been updated to include
this new field, while the old fields have been cleaned up. The new json
file includes the npc frame id for the asset that will be used and it
includes a new `events` field which is an array of object that will be
used for the npc when the player interacts with them.

The new data structure will allow us to do things like have the npc talk
to the player, heal the player, give items, battle, etc. To support this
the npc class and world scene classes have been updated to pass this
data when the npc is created. Then, when the player interacts with the npc
a new method in the world scene is called. This method keeps track of which
events have been processed, and will take action on the relevant event
data.

As an example, if an npc has 2 events that are just messages, then the player
will see the dialog ui (the same as before), and after talking to the npc
twice, the dialog ui goes away (same as before).

Started adding in logic for each of the custom event types, like
healing the player and fading the scene in and out.

updated the world scene data to support a new property for when the player
is knocked out during a battle. when this is set to `true`, the world
scene will attempt to lookup the players re-spawn location based on the
data in the TILED JSON data file.

Once the location is found, the world scene will update the data in the
data manager to match that location and player direction.

Signed-off-by: Scott Westover <scottwestover2006@gmail.com>